### PR TITLE
Use `easy_install` to install `pip` on all platforms

### DIFF
--- a/bootstrap/common.sh
+++ b/bootstrap/common.sh
@@ -1,3 +1,4 @@
+easy_install pip
 pip install --upgrade setuptools  # to provide package introspection
 pip install Pygments  # we don't know why
 pip install PasteScript  # to run the development server

--- a/bootstrap/osx.sh
+++ b/bootstrap/osx.sh
@@ -1,1 +1,0 @@
-easy_install pip

--- a/bootstrap/ubuntu.sh
+++ b/bootstrap/ubuntu.sh
@@ -1,9 +1,11 @@
 # Prerequisites
-apt-get install gettext
-apt-get install git
-apt-get install python-pip
-apt-get install python-dev
-apt-get install python-numpy
-apt-get install python-pymongo
-apt-get install python-scipy
-apt-get install gfortran
+
+apt-get update
+apt-get --assume-yes install gettext
+apt-get --assume-yes install git
+apt-get --assume-yes install python-setuptools
+apt-get --assume-yes install python-dev
+apt-get --assume-yes install python-numpy
+apt-get --assume-yes install python-pymongo
+apt-get --assume-yes install python-scipy
+apt-get --assume-yes install gfortran


### PR DESCRIPTION
@fpagnoux If I remember well, you had to `apt-get` `pip` on a clean Ubuntu, right? And @noirbizarre recommended to install it with a Python tool, hence this patch.

Please confirm this would do the trick  :)
