### PR TITLE
Handle multiple environments

### DIFF
--- a/config/development.ini
+++ b/config/development.ini
@@ -1,0 +1,1 @@
+../openfisca/web-api/development-france.ini

--- a/config/mes-aides.ini
+++ b/config/mes-aides.ini
@@ -1,0 +1,55 @@
+# OpenFisca-Web-API - Development environment configuration
+#
+# The %(here)s variable will be replaced with the parent directory of this file.
+
+[DEFAULT]
+debug = true
+# Uncomment and replace with the address which should receive any error reports
+email_to = mes-aides@sgmap.fr
+smtp_server = localhost
+error_email_from = openfisca-mes-aides@sgmap.fr
+error_from = openfisca-mes-aides@sgmap.fr
+
+[server:main]
+use = egg:gunicorn#main
+workers = 9
+proc_name = openfisca
+host = 127.0.0.1
+port = 12000
+
+[app:main]
+use = egg:OpenFisca-Web-API
+country_package = openfisca_france
+log_level = DEBUG
+reforms =
+	openfisca_france.reforms.aides_ville_paris.build_reform
+	openfisca_france.reforms.aides_cd93.build_reform
+
+# Logging configuration
+[loggers]
+keys = root, openfisca_web_api
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = INFO
+handlers = console
+
+[logger_openfisca_web_api]
+level = DEBUG
+handlers =
+qualname = openfisca_web_api
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s,%(msecs)03d %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/start.sh
+++ b/start.sh
@@ -1,1 +1,5 @@
-paster serve --reload `dirname $0`/openfisca/web-api/development-france.ini
+#!/bin/bash
+# 1st param = config name. Defaults to `development`.
+# Available configs are in `config` folder.
+
+paster serve --reload `dirname $0`/config/${1:-development}.ini

--- a/update.sh
+++ b/update.sh
@@ -1,14 +1,13 @@
 #!/bin/bash
+# 1st param (optional): target branch. Defaults to master.
+TARGET_BRANCH=${1:-master}
 
 set -ex
 
 cd `dirname $0`
 
-if [[ $1 != '--dev' ]]  # allow testing new versions locally
-then
-	git checkout master
-	git pull origin master
-fi
+git checkout $TARGET_BRANCH
+git pull origin $TARGET_BRANCH
 
 git submodule sync
 git submodule update --init --recursive


### PR DESCRIPTION
Import production environment from production server.

Use with `./start.sh mes-aides` (default `./start.sh` still works).

@jdesboeufs The upstart script used `/usr/local/bin/gunicorn --paster production.ini` rather than `paster serve`. What are the advantages or preferring `gunicorn`?
