### PR TITLE
Use update.sh to deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+config/current.ini

--- a/config/mes-aides.ini
+++ b/config/mes-aides.ini
@@ -11,10 +11,8 @@ error_email_from = openfisca-mes-aides@sgmap.fr
 error_from = openfisca-mes-aides@sgmap.fr
 
 [server:main]
-use = egg:gunicorn#main
-workers = 9
-proc_name = openfisca
-host = 127.0.0.1
+use = egg:Paste#http
+host = 0.0.0.0
 port = %PORT%
 
 [app:main]

--- a/config/mes-aides.ini
+++ b/config/mes-aides.ini
@@ -15,7 +15,7 @@ use = egg:gunicorn#main
 workers = 9
 proc_name = openfisca
 host = 127.0.0.1
-port = 12000
+port = %PORT%
 
 [app:main]
 use = egg:OpenFisca-Web-API

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 # 1st param = config name. Defaults to `development`.
 # Available configs are in `config` folder.
+PORT=${PORT:-2000}
 
-paster serve --reload `dirname $0`/config/${1:-development}.ini
+cd `dirname $0`
+
+sed s/%PORT%/$PORT/ config/${1:-development}.ini > config/current.ini
+
+paster serve --reload config/current.ini

--- a/update.sh
+++ b/update.sh
@@ -6,8 +6,7 @@ set -ex
 
 cd `dirname $0`
 
-git checkout $TARGET_BRANCH
-git pull origin $TARGET_BRANCH
+git checkout --force origin/$TARGET_BRANCH
 
 git submodule sync
 git submodule update --init --recursive

--- a/update.sh
+++ b/update.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
-# 1st param (optional): target branch. Defaults to master.
-TARGET_BRANCH=${1:-master}
+# 1st param (optional): force the target branch to update to. WILL LOSE UNCOMMITTED CHANGES. Defaults to staying on current branch.
 
 set -ex
 
 cd `dirname $0`
 
-git checkout --force origin/$TARGET_BRANCH
+if [[ -n $1 ]]
+then git checkout --force origin/$1
+fi
 
 git submodule sync
 git submodule update --init --recursive

--- a/update.sh
+++ b/update.sh
@@ -6,7 +6,9 @@ set -ex
 cd `dirname $0`
 
 if [[ -n $1 ]]
-then git checkout --force origin/$1
+then
+	git fetch origin
+	git checkout --force origin/$1
 fi
 
 git submodule sync

--- a/update.sh
+++ b/update.sh
@@ -12,5 +12,5 @@ git pull origin $TARGET_BRANCH
 git submodule sync
 git submodule update --init --recursive
 
-git submodule foreach python setup.py develop
+git submodule foreach python setup.py develop --user
 git submodule foreach pip install --user --editable .


### PR DESCRIPTION
- Allow port to be defined at runtime.
- Scope all the install in user.
- Do not require git committing rights on repo.
