### PR TITLE
Update start and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-This repository eases the deployment of a production [OpenFisca](http://openfisca.fr) instance.
+This repository eases the deployment of the production [OpenFisca](http://openfisca.fr) instance used by mes-aides.gouv.fr.
 
-> Ce dépôt facilite le déploiement d'une instance d'[OpenFisca](http://openfisca.fr) en production.
+> Ce dépôt facilite le déploiement de l'instance d'[OpenFisca](http://openfisca.fr) utilisée en production pour mes-aides.gouv.fr.
 
 
 Rationale
@@ -40,7 +40,7 @@ Usage
 ### Run
 
 ```
-git clone https://github.com/sgmap/openfisca.git && openfisca/update.sh
+git clone https://github.com/sgmap/openfisca.git && openfisca/update.sh && openfisca/start.sh
 ```
 
 ### Extensions

--- a/config/development.ini
+++ b/config/development.ini
@@ -1,1 +1,0 @@
-../openfisca/web-api/development-france.ini

--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# 1st param = config name. Defaults to `development`.
-# Available configs are in `config` folder.
 
 cd `dirname $0`
 
-paster serve --reload config/${1:-development}.ini
+./generateMesAidesConfig.sh
+
+paster serve --reload config/current.ini


### PR DESCRIPTION
- Use `mes-aides.ini` confing file when running `start.sh`
- Update `REAMDE.md`

It seems that only mes-aides uses this repository, so let's be honest and not pay genericity cost for nothing. The goal of this repository is then just to help to deploy an `openfisca` instance compatible with `mes-aides`, and `start.sh` doesn't need a parameter.
